### PR TITLE
Bug 946989 - [Messages][Drafts] Duplicate threadless drafts get saved

### DIFF
--- a/apps/sms/js/drafts.js
+++ b/apps/sms/js/drafts.js
@@ -74,9 +74,25 @@
 
         // If there is an existing draft for this
         // threadId, delete it.
+        // This should be replaced by a general
+        // replacement method.
         if (threadId !== null && thread.length) {
           this.delete(stored);
           canSkipDistinction = true;
+        }
+
+        // If there is an existing threadless draft
+        // with the same id, delete it.
+        // This should be replaced by a general
+        // replacement method.
+        if (threadId === null && thread.length) {
+          thread.some((function(d, i) {
+            if (d.id === draft.id) {
+              this.delete(d);
+              stored = null;
+              return true;
+            }
+          }), this);
         }
 
         // If the new draft is distinct from the stored one

--- a/apps/sms/js/thread_ui.js
+++ b/apps/sms/js/thread_ui.js
@@ -2521,11 +2521,14 @@ var ThreadUI = global.ThreadUI = {
       threadId = threadId || null;
     }
 
+    var draftId = MessageManager.draft ? MessageManager.draft.id : null;
+
     draft = new Draft({
       recipients: recipients,
       content: content,
       threadId: threadId,
-      type: type
+      type: type,
+      id: draftId
     });
 
     Drafts.add(draft);
@@ -2540,6 +2543,8 @@ var ThreadUI = global.ThreadUI = {
       thread.timestamp = draft.timestamp;
 
       ThreadListUI.updateThread(thread);
+    } else {
+      ThreadListUI.updateThread(draft);
     }
     MessageManager.draft = null;
   }

--- a/apps/sms/test/unit/drafts_test.js
+++ b/apps/sms/test/unit/drafts_test.js
@@ -27,7 +27,8 @@ suite('Drafts', function() {
       timestamp: 1,
       threadId: 42,
       subject: 'This is a subject',
-      type: 'sms'
+      type: 'sms',
+      id: 1
     });
     d2 = new Draft({
       recipients: ['555'],
@@ -35,7 +36,8 @@ suite('Drafts', function() {
       timestamp: 2,
       threadId: 44,
       subject: 'This is a subject',
-      type: 'sms'
+      type: 'sms',
+      id: 2
     });
     d3 = new Draft({
       recipients: ['555', '222'],
@@ -43,7 +45,8 @@ suite('Drafts', function() {
       timestamp: 3,
       threadId: 1,
       subject: 'This is a subject',
-      type: 'sms'
+      type: 'sms',
+      id: 3
     });
     d4 = new Draft({
       recipients: ['555', '333'],
@@ -51,7 +54,8 @@ suite('Drafts', function() {
       timestamp: 4,
       threadId: 2,
       subject: 'This is a subject',
-      type: 'sms'
+      type: 'sms',
+      id: 4
     });
     d5 = new Draft({
       recipients: ['555', '444'],
@@ -59,23 +63,8 @@ suite('Drafts', function() {
       timestamp: 5,
       threadId: null,
       subject: 'This is a subject',
-      type: 'sms'
-    });
-    d6 = new Draft({
-      recipients: ['555', '444'],
-      content: ['This is a different draft message'],
-      timestamp: 5,
-      threadId: null,
-      subject: 'This is a subject',
-      type: 'sms'
-    });
-    d7 = new Draft({
-      recipients: ['555', '444'],
-      content: ['This is a draft message'],
-      timestamp: 5,
-      threadId: null,
-      subject: 'This is a different subject',
-      type: 'sms'
+      type: 'sms',
+      id: 5
     });
     d6 = new Draft({
       recipients: ['123456'],
@@ -92,7 +81,17 @@ suite('Drafts', function() {
       ],
       timestamp: Date.now() - (3600000 * 2),
       threadId: 8,
-      type: 'mms'
+      type: 'mms',
+      id: 6
+    });
+    d7 = new Draft({
+      recipients: ['555', '444'],
+      content: ['This is a draft message'],
+      timestamp: 5,
+      threadId: null,
+      subject: 'This is a different subject',
+      type: 'sms',
+      id: 7
     });
   });
 
@@ -156,6 +155,32 @@ suite('Drafts', function() {
       assert.notEqual(Drafts.byThreadId(44).latest.id, latestId);
       assert.equal(Drafts.byThreadId(44).length, 1);
     });
+
+    test('add threadless draft of same draft.id replaces previous', function() {
+      Drafts.add(d5);
+
+      assert.equal(
+        Drafts.byThreadId(null).latest.content,
+        'This is a draft message'
+      );
+
+      Drafts.add({
+        recipients: ['555', '444'],
+        content: ['This is a new draft message'],
+        timestamp: 5,
+        threadId: null,
+        subject: 'This is a subject',
+        type: 'sms',
+        id: 5
+      });
+
+      assert.equal(
+        Drafts.byThreadId(null).latest.content,
+        'This is a new draft message'
+      );
+      assert.equal(Drafts.byThreadId(null).length, 1);
+    });
+
   });
 
   suite('delete() >', function() {

--- a/apps/sms/test/unit/thread_ui_test.js
+++ b/apps/sms/test/unit/thread_ui_test.js
@@ -20,6 +20,7 @@ requireApp('sms/js/drafts.js');
 requireApp('sms/js/threads.js');
 requireApp('sms/js/thread_ui.js');
 requireApp('sms/js/thread_list_ui.js');
+requireApp('sms/js/fixed_header.js');
 requireApp('sms/js/is-equal.js');
 requireApp('sms/js/utils.js');
 requireApp('sms/js/message_manager.js');
@@ -160,6 +161,7 @@ suite('thread_ui.js >', function() {
 
     ThreadUI.recipients = null;
     ThreadUI.init();
+    ThreadListUI.init();
     realMozMobileMessage = ThreadUI._mozMobileMessage;
     ThreadUI._mozMobileMessage = MockNavigatormozMobileMessage;
   });
@@ -3686,11 +3688,12 @@ suite('thread_ui.js >', function() {
   });
 
   suite('saveMessageDraft() > ', function() {
-    var spy, arg;
+    var addSpy, updateSpy, arg;
 
     setup(function() {
       window.location.hash = '#new';
-      spy = this.sinon.spy(Drafts, 'add');
+      addSpy = this.sinon.spy(Drafts, 'add');
+      updateSpy = this.sinon.spy(ThreadListUI, 'updateThread');
 
       ThreadUI.recipients.add({
         number: '999'
@@ -3701,7 +3704,7 @@ suite('thread_ui.js >', function() {
 
     test('has entered content and recipients', function() {
       ThreadUI.saveMessageDraft();
-      arg = spy.firstCall.args[0];
+      arg = addSpy.firstCall.args[0];
 
       assert.deepEqual(arg.recipients, ['999']);
       assert.deepEqual(arg.content, ['foo']);
@@ -3710,7 +3713,7 @@ suite('thread_ui.js >', function() {
     test('has entered recipients but not content', function() {
       Compose.clear();
       ThreadUI.saveMessageDraft();
-      arg = spy.firstCall.args[0];
+      arg = addSpy.firstCall.args[0];
 
       assert.deepEqual(arg.recipients, ['999']);
       assert.deepEqual(arg.content, []);
@@ -3719,10 +3722,16 @@ suite('thread_ui.js >', function() {
     test('has entered content but not recipients', function() {
       ThreadUI.recipients.remove('999');
       ThreadUI.saveMessageDraft();
-      arg = spy.firstCall.args[0];
+      arg = addSpy.firstCall.args[0];
 
       assert.deepEqual(arg.recipients, []);
       assert.deepEqual(arg.content, ['foo']);
+    });
+
+    test('thread is updated in thread list', function() {
+      ThreadUI.saveMessageDraft();
+
+      assert.isTrue(updateSpy.calledOnce);
     });
 
   });


### PR DESCRIPTION
- `drafts.js`
  - changed `add()` to delete existing, threadless drafts if the new draft being added matches draft.id
- `thread_ui.js`
  - ensures that the thread in the thread list is updated if a draft gets updated
- `drafts_test.js`
  - tests that threadless drafts are properly replaced
- `thread_ui_test.js`
  - tests that thread update is called upon draft saving
